### PR TITLE
Add extra packages during container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN curl -O ${PLEXPKG} && \
     rm -fr plexmediaserver_*.deb
 
 #Copy start script and make executable
-COPY ./start.sh .
-RUN chmod +x ./start.sh
+COPY start.sh start.sh
+RUN chmod +x start.sh
 
 #Set entrypoint of Plex start script
 ENTRYPOINT [ "/app/start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -q update && \
     apt-get -qy --force-yes dist-upgrade
 
 #Install Packages
-RUN apt-get install -qy --force-yes curl
+RUN apt-get install -qy --force-yes curl dbus avahi-daemon
 
 #Download Plex
 RUN curl $PLEXPKG -o /var/tmp/plexmediaserver.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Micheal Waltz <ecliptik@gmail.com>
 ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8 LC_ALL=C.UTF-8 LANGUAGE=en_US.UTF-8
 
 #Plex install package to download
-ENV PLEXPKG=https://downloads.plex.tv/plex-media-server/1.10.0.4523-648bc61d4/plexmediaserver_1.10.0.4523-648bc61d4_amd64.deb
+ENV PLEXPKG=https://downloads.plex.tv/plex-media-server/1.9.3.4290-9798172d4/plexmediaserver_1.9.3.4290-9798172d4_amd64.deb
 
 #App Dir var
 ENV APPDIR=/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ ENV PLEXPKG=https://downloads.plex.tv/plex-media-server/0.9.16.4.1911-ee6e505/pl
 #App Dir var
 ENV APPDIR=/app
 
-#Install Packages
-RUN apt-get install -qy --force-yes curl dbus avahi-daemon
-
 #Volumes
 VOLUME /config
 VOLUME /data
@@ -27,7 +24,7 @@ EXPOSE 32400
 #Update system
 RUN apt-get -q update && \
     apt-get -qy --allow-downgrades --allow-remove-essential --allow-change-held-packages upgrade && \
-    apt-get install -qy --allow-downgrades --allow-remove-essential --allow-change-held-packages curl && \
+    apt-get install -qy --allow-downgrades --allow-remove-essential --allow-change-held-packages curl dbus avahi-daemon && \
     apt-get clean && \
     rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Micheal Waltz <ecliptik@gmail.com>
 ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8 LC_ALL=C.UTF-8 LANGUAGE=en_US.UTF-8
 
 #Plex install package to download
-ENV PLEXPKG=https://downloads.plex.tv/plex-media-server/1.1.4.2757-24ffd60/plexmediaserver_1.1.4.2757-24ffd60_amd64.deb
+ENV PLEXPKG=https://downloads.plex.tv/plex-media-server/1.10.0.4523-648bc61d4/plexmediaserver_1.10.0.4523-648bc61d4_amd64.deb
 
 #App Dir var
 ENV APPDIR=/app

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker run -d -h *your_host_name* -v /*your_config_location*:/config -v /*your_v
 or for auto detection add --net="host". Though be aware this more insecure but should be fine on your personal servers.
 
 ```
-docker run -d --net="host" -h *your_host_name* -v /*your_config_location*:/config -v /*your_videos_location*:/data -p 32400:32400  plex
+docker run -d --net="host" -v /*your_config_location*:/config -v /*your_videos_location*:/data -p 32400:32400  plex
 ```
 
 The first time it runs, it will initialize the config directory and terminate.


### PR DESCRIPTION
Plex emits warnings and behaves a bit strangely if the dbus and avahi bits aren't present in the container.  Adding them makes the web interface work better, it seems.

There was also a typo in the README
